### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ import(
 type C struct{}
 
 func (c *C) Delete(a iface.Filter) error {
-	// ... We can of course insert custom bussiness logic here.
+	// ... We can of course insert custom business logic here.
 	_, err := a.RemoveAll()
 	return err
 }


### PR DESCRIPTION
@crufter, I've corrected a typographical error in the documentation of the [nocrud](https://github.com/crufter/nocrud) project. Specifically, I've changed bussiness to business. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
